### PR TITLE
Optimization update

### DIFF
--- a/Application.cpp
+++ b/Application.cpp
@@ -195,7 +195,7 @@ bool Application::initApplication(HINSTANCE hInstance, HWND hwnd)
 		return false;
 
 	this->view = XMMatrixLookAtLH(XMVectorSet(0.0f, 0.0f, -3.0f, 1.0f), XMVectorSet(0.0f, 0.0f, 0.0f, 1.0f), XMVectorSet(0.0f, 1.0f, 0.0f, 1.0f));
-	this->projection = XMMatrixPerspectiveFovLH(XM_PI * 0.45f, ((float)WIDTH) / HEIGHT, 0.01f, 500.0f);
+	this->projection = XMMatrixPerspectiveFovLH(XM_PI * 0.45f, ((float)WIDTH) / HEIGHT, SCREEN_NEAR, SCREEN_DEPTH);
 
 	this->inputHandler = new Movement();
 	this->inputHandler->initialize(hwnd);
@@ -320,18 +320,6 @@ void Application::Release()
 		this->pSceneShadowMap->Release();
 }
 
-void Application::switchScene()
-{
-	this->currentScene = (this->currentScene + 1) % NUMOFSCENES;
-	if (this->currentScene == 2)
-	{
-		this->view = XMMatrixLookAtLH(XMVectorSet(0.0f, 0.3f, -2.0f, 1.0f), XMVectorSet(0.0f, 0.0f, 0.0f, 1.0f), XMVectorSet(0.0f, 1.0f, 0.0f, 1.0f));
-	}
-	else
-	{
-		this->view = XMMatrixLookAtLH(XMVectorSet(0.0f, 0.0f, -3.0f, 1.0f), XMVectorSet(0.0f, 0.0f, 0.0f, 1.0f), XMVectorSet(0.0f, 1.0f, 0.0f, 1.0f));
-	}
-}
 
 void Application::textToScreen(wstring text, XMFLOAT2 position, XMFLOAT2 scaling)
 {

--- a/Application.h
+++ b/Application.h
@@ -20,13 +20,6 @@
 #pragma comment (lib, "d3d11.lib")
 #pragma comment (lib, "d3dcompiler.lib")
 
-
-//Scenes
-// SceneOne = Deferred Rendering
-// SceneTwo = Normal Mapping
-#define NUMOFSCENES 3
-
-
 //collect namespace:s here
 using namespace DirectX;
 using namespace std;
@@ -35,8 +28,9 @@ using namespace std;
 #define WIDTH 1280
 #define HEIGHT 720
 
+
 //if you add a new scene you have made it is very important to forward declare 
-//the class so the compiler knows we are using an interafce, to do this just write: class SceneClassName;
+//to do this just write: class SceneClassName;
 class SceneNormalMapping;
 class SceneDeferredRendering;
 class SceneShadowMapping;
@@ -64,7 +58,6 @@ public:
 	ID3D11DepthStencilState* pDepthStencilState;
 	ID3D11DepthStencilState* pDepthDisabledStencilState;
 	ID3D11RasterizerState* pRasterState;
-	void switchScene();
 	//matrices
 	XMMATRIX view;
 	XMMATRIX projection;
@@ -74,8 +67,8 @@ public:
 	XMFLOAT2 m_fontPos;
 	void textToScreen(wstring text, XMFLOAT2 position, XMFLOAT2 scaling);
 	void camInfoToScreen(XMFLOAT2 position, XMFLOAT2 scaling);
-private:
 	Movement * inputHandler;
+private:
 	//Scene pointers
 	SceneShadowMapping * pSceneShadowMap;
 	SceneNormalMapping * pSceneNormalMap;

--- a/DiamondSqaure.cpp
+++ b/DiamondSqaure.cpp
@@ -30,14 +30,14 @@ vector<float> DiamondSqaure::createDiamondSquare(int mapSize, int initStepSize, 
 		noiseScale = noiseScale / 2;
 	}
 	//add smoothing to the values and repeat X given times for further smoothing, 1 time is enough for now, but play with it for lulz
-	smoothValues(pow(2, 3) + 1);
+	smoothValues((int)pow(2,2) + 1);
 	return this->diamondSquare;
 }
 
 float DiamondSqaure::fRand()
 {
-	int min = -5;
-	int max = 60;
+	int min = -15;
+	int max = 15;
 	float randomNumber = (float)rand() / RAND_MAX;
 	return (min + randomNumber * (max - (min)));
 }

--- a/HeightMap.h
+++ b/HeightMap.h
@@ -9,9 +9,21 @@
 #include "WICTextureLoader.h"
 #include <fstream>
 #include "DiamondSqaure.h"
+#include "QuadTree.h"
+#include "Application.h"
+
+#define SCREEN_DEPTH 15.f
+#define SCREEN_NEAR 0.01f
+#define TOP_DOWN_DEPTH 1000.f
+#define TOP_DOWN_WIDTH 300
+#define TOP_DOWN_HEIGHT 300
+#define TOP_DOWN_X 980
+#define TOP_DOWN_Y 0
 
 using namespace DirectX;
 using namespace std;
+
+class Application;
 
 class HeightMap
 {
@@ -21,18 +33,11 @@ public:
 
 	bool initialize(ID3D11Device * pDev, HWND hwnd, int mapSize, float offset);
 	void Release();
-	void Render(ID3D11DeviceContext * pDevCon, XMMATRIX world, XMMATRIX view, XMMATRIX projection);
+	void Render(Application * pApp, XMMATRIX world, XMMATRIX view, XMMATRIX projection);
 	int getNrOfTriangles() const;
 
 private:
-	struct VertexTypeHeightMap
-	{
-		XMFLOAT3 vertex;
-		XMFLOAT2 tex;
-		XMFLOAT3 normal;
-		XMFLOAT3 tangent;
-		XMFLOAT3 binormal;
-	};
+	
 	struct MatrixBufferHeightMap
 	{
 		XMMATRIX world;
@@ -43,12 +48,14 @@ private:
 	int m_mapSize;  //this is the maps size (the size of one side, nr of vertices is then size times size)
 	float m_offset; //this offset determines how far vertices are apart from each other
 
+	ViewFrustum m_viewFrustum;
+	QuadTree m_quadTree;
+
 	vector<float> m_heightValues;
 	vector<VertexTypeHeightMap> m_vertices;
-	vector<int> m_indices;
+	vector<unsigned int> m_indices;
 
 	ID3D11Buffer * m_vertexBuffer;
-	ID3D11Buffer * m_indexBuffer;
 	ID3D11Buffer * m_MatrixBuffer;
 
 	ID3D11InputLayout * m_InputLayout;
@@ -64,6 +71,10 @@ private:
 
 	ID3D11RasterizerState * m_rasterState; //this is soley for wireframe drawing
 	D3D11_VIEWPORT m_Viewport;
+	D3D11_VIEWPORT m_TopDownView;
+
+	XMMATRIX m_top_down_view;
+	XMMATRIX m_top_down_projection;
 
 	bool initShaders(ID3D11Device * pDev, HWND hwnd, WCHAR * vtx_path, WCHAR * px_path);
 	bool initTextures(ID3D11Device * pDev, WCHAR * colorTex, WCHAR * normalTex);
@@ -73,6 +84,7 @@ private:
 	void generateHeightValues();
 	bool buildHeightMap(ID3D11Device * pDev);
 	void calculateNormalTangentBinormal(int vtx1, int vtx2, int vtx3);
+	void constructViewProjectionMatrices(Application *pApp);
 
 	void outputErrorMessage(ID3D10Blob * error, HWND hwnd, WCHAR * file);
 

--- a/Includes.h
+++ b/Includes.h
@@ -1,0 +1,27 @@
+#include "Application.h"
+#include "DeferredBuffer.h"
+#include "DeferredShader.h"
+#include "LightShader.h"
+#include "Model.h"
+#include "ModelLoader.h"
+#include "NormalMapShader.h"
+#include "SceneDeferredRendering.h"
+#include "SceneInterface.h"
+#include "SceneNormalMapping.h"
+#include "WICTextureLoader.h"
+#include <d3d11.h>
+#include <d3dcompiler.h>
+#include <chrono>
+#include <DirectXMath.h>
+
+//collect comments for the linker to include libraries here
+#pragma comment (lib, "d3d11.lib")
+#pragma comment (lib, "d3dcompiler.lib")
+
+//collect namespace:s here
+using namespace DirectX;
+using namespace std;
+
+//collect macros here
+#define WIDTH 1280
+#define HEIGHT 720

--- a/Movement.cpp
+++ b/Movement.cpp
@@ -23,6 +23,7 @@ void Movement::initialize(HWND hwnd)
 	mMouse->SetWindow(hwnd);
 	this->startState = mMouse->GetState();
 	this->start_clock_movement = high_resolution_clock::now();
+	this->rotation_clock_start = high_resolution_clock::now();
 }
 
 void Movement::updateCamera(XMMATRIX &view)
@@ -74,19 +75,47 @@ void Movement::detectKeys(int &currentScene)
 		
 		if (kb.W)
 		{
-			camPosition += posToTarget * MOVESPEED;
+			if (currentScene == Scenes::SceneFour)
+			{
+				camPosition += posToTarget * MOVESPEED_HEIGHTMAP;
+			}
+			else
+			{
+				camPosition += posToTarget * MOVESPEED;
+			}
 		}
 		if (kb.S)
 		{
-			camPosition -= posToTarget * MOVESPEED;
+			if (currentScene == Scenes::SceneFour)
+			{
+				camPosition -= posToTarget * MOVESPEED_HEIGHTMAP;
+			}
+			else
+			{
+				camPosition -= posToTarget * MOVESPEED;
+			}
 		}
 		if (kb.D)
 		{
-			camPosition -= sideVector * MOVESPEED;
+			if (currentScene == Scenes::SceneFour)
+			{
+				camPosition -= sideVector * MOVESPEED_HEIGHTMAP;
+			}
+			else
+			{
+				camPosition -= sideVector * MOVESPEED;
+			}
 		}
 		if (kb.A)
 		{
-			camPosition += sideVector * MOVESPEED;
+			if (currentScene == Scenes::SceneFour)
+			{
+				camPosition += sideVector * MOVESPEED_HEIGHTMAP;
+			}
+			else
+			{
+				camPosition += sideVector * MOVESPEED;
+			}
 		}
 		this->start_clock_movement = high_resolution_clock::now();
 	}
@@ -94,14 +123,19 @@ void Movement::detectKeys(int &currentScene)
 
 	auto currState = mMouse->GetState();
 
-	if (currState.positionMode == Mouse::MODE_RELATIVE)
-	{	
-		if (currState.x != startState.x || currState.y != startState.y)
-		{
-			camYaw += float(startState.x) * CAMYAWPITCHOFFSET;
-			camPitch += float(startState.y) * CAMYAWPITCHOFFSET;
+	rotation_clock_current = high_resolution_clock::now();
+	delta_time = rotation_clock_current - rotation_clock_start;
 
-			startState = currState;
+	if (delta_time.count() > (1000 / FRAME_UPDATES_MOVEMENT))
+	{
+		if (currState.positionMode == Mouse::MODE_RELATIVE)
+		{
+			if (currState.x != startState.x || currState.y != startState.y)
+			{
+				camYaw += float(startState.x) * CAMYAWPITCHOFFSET;
+				camPitch += float(startState.y) * CAMYAWPITCHOFFSET;
+				startState = currState;
+			}
 		}
 	}
 	mMouse->SetMode(currState.leftButton ? Mouse::MODE_RELATIVE : Mouse::MODE_ABSOLUTE);

--- a/Movement.h
+++ b/Movement.h
@@ -13,6 +13,7 @@
 #include <chrono>
 
 #define MOVESPEED 0.1f
+#define MOVESPEED_HEIGHTMAP 1.0f;
 #define CAMYAWPITCHOFFSET 0.001f
 #define FRAME_UPDATES_MOVEMENT 60
 
@@ -47,6 +48,7 @@ private:
 	unique_ptr<Mouse> mMouse;
 	Mouse::State startState;
 	high_resolution_clock::time_point start_clock_movement, current_clock_movement;
+	high_resolution_clock::time_point rotation_clock_start, rotation_clock_current;
 
 	
 public:

--- a/QuadTree.cpp
+++ b/QuadTree.cpp
@@ -1,0 +1,294 @@
+#include "QuadTree.h"
+
+
+
+QuadTree::QuadTree()
+{
+	m_parent = nullptr;
+}
+
+
+QuadTree::~QuadTree()
+{
+}
+
+bool QuadTree::initialize(vector<unsigned int> indices, int mapSize, float delta, ID3D11Device * pDev)
+{
+	m_indices = indices;
+	m_mapSize = mapSize;
+	deltaSpace = delta;
+
+	//create the parent node
+	m_parent = new NodeTypeQuadTree;
+	if (m_parent == nullptr)
+		return false;
+
+	//recursively build the quad tree
+	createTreeNode(m_parent, 0, 0, mapSize, pDev);
+
+	//once the tree is build and the vertices are stored in the vertex buffers, release the vector to free up memory space
+	indices.clear();
+	m_indices.clear();
+
+	return true;
+}
+
+void QuadTree::Release()
+{
+	if (m_parent)
+	{
+		ReleaseNode(m_parent);
+		delete m_parent;
+		m_parent = nullptr;
+	}
+}
+
+void QuadTree::Render(ViewFrustum & viewFrustum, ID3D11DeviceContext * pDevCon)
+{
+	m_drawCount = 0;
+
+	RenderNode(m_parent, viewFrustum, pDevCon);
+}
+
+void QuadTree::createTreeNode(NodeTypeQuadTree * node, int xStart, int zStart, int size, ID3D11Device * pDev)
+{
+	int numOfTriangles;
+	vector<unsigned long> indices;
+
+	D3D11_BUFFER_DESC indexBufferDesc;
+	D3D11_SUBRESOURCE_DATA indexData;
+	HRESULT hr;
+
+	//initialize node and set it position in world
+	node->xIndex = xStart;
+	node->zIndex = zStart;
+	node->size = size;
+	node->indexBuffer = NULL;
+	node->radius = node->size * deltaSpace;
+	node->cubeCenterVertex.x = (node->xIndex * deltaSpace) + node->radius;
+	node->cubeCenterVertex.y = 0.0f;
+	node->cubeCenterVertex.z = (node->zIndex * deltaSpace) + node->radius;
+
+	for (int i = 0; i < 4; i++)
+		node->nodes[i] = NULL;
+
+	numOfTriangles = (int)pow((size), 2) * 2;
+	node->triangleCount = numOfTriangles;
+
+	//case 1 - there are no triangles in this node
+	if (numOfTriangles == 0)
+		return;
+
+	//case 2 - if there are too many triangles split it up into 4 new quads
+	if (numOfTriangles > MAX_TRIANGLES)
+	{
+		XMFLOAT2 cube1, cube2, cube3, cube4;
+		int halfSide = (int)(node->size * 0.5);
+
+		node->nodes[0] = new NodeTypeQuadTree;
+		node->nodes[1] = new NodeTypeQuadTree;
+		node->nodes[2] = new NodeTypeQuadTree;
+		node->nodes[3] = new NodeTypeQuadTree;
+
+		createTreeNode(node->nodes[0], node->xIndex, node->zIndex, halfSide, pDev);
+		createTreeNode(node->nodes[1], node->xIndex + halfSide, node->zIndex, halfSide, pDev);
+		createTreeNode(node->nodes[2], node->xIndex, node->zIndex + halfSide, halfSide, pDev);
+		createTreeNode(node->nodes[3], node->xIndex + halfSide, node->zIndex + halfSide, halfSide, pDev);
+
+		return;
+	}
+
+	//case 3 - the right nr of triangles exist create the vertex and index buffer
+	//find the vertex that equals to centXZ from the vertex vector
+
+	int z, x, width, depth;
+	x = node->xIndex;
+	z = node->zIndex;
+	width = x + node->size;
+	depth = z + node->size;
+	int offset = 6 * (m_mapSize - 1);
+
+	for (z; z < depth; z++)
+	{
+		for (x; x < width; x++)
+		{
+			int index = x * 6 + ((offset) * z);
+			indices.push_back(m_indices[index]);
+			indices.push_back(m_indices[index + 1]);
+			indices.push_back(m_indices[index + 2]);
+
+			indices.push_back(m_indices[index + 3]);
+			indices.push_back(m_indices[index + 4]);
+			indices.push_back(m_indices[index + 5]);
+		}
+		x = node->xIndex;
+	}
+
+	node->triangleCount = (int)indices.size() / 3;
+	// set up the description of the static index buffer
+	indexBufferDesc.Usage = D3D11_USAGE_DEFAULT;
+	indexBufferDesc.ByteWidth = sizeof(unsigned long) * (unsigned int)indices.size();
+	indexBufferDesc.BindFlags = D3D11_BIND_INDEX_BUFFER;
+	indexBufferDesc.CPUAccessFlags = 0;
+	indexBufferDesc.MiscFlags = 0;
+	indexBufferDesc.StructureByteStride = 0;
+
+	// assign the subresource structure a pointer t o the index data
+	indexData.pSysMem = indices.data();
+	indexData.SysMemPitch = 0;
+	indexData.SysMemSlicePitch = 0;
+
+	// create index buffer
+	hr = pDev->CreateBuffer(&indexBufferDesc, &indexData, &node->indexBuffer);
+
+	//free up memory
+	indices.clear();
+	//done
+}
+
+
+void QuadTree::ReleaseNode(NodeTypeQuadTree * node)
+{
+	// Recursively go down the tree and release the bottom nodes first.
+	for (int i = 0; i < 4; i++)
+	{
+		if (node->nodes[i] != NULL)
+		{
+			ReleaseNode(node->nodes[i]);
+		}
+	}
+
+	// Release the index buffer for this node.
+	if (node->indexBuffer)
+	{
+		node->indexBuffer->Release();
+		node->indexBuffer = 0;
+	}
+
+	// Release the four child nodes.
+	for (int i = 0; i < 4; i++)
+	{
+		if (node->nodes[i])
+		{
+			delete node->nodes[i];
+			node->nodes[i] = 0;
+		}
+	}
+
+	return;
+}
+
+void QuadTree::RenderNode(NodeTypeQuadTree * node, ViewFrustum & viewFrustum, ID3D11DeviceContext * pDevCon)
+{
+	bool result = false;
+	int count, indexCount;
+
+	//do frustum check on the cube
+	result = viewFrustum.checkCube(node->cubeCenterVertex, node->radius);
+	if (result) //if it cant be seen then none of its children can be either, stop here
+		return;
+
+	if (!node->indexBuffer) //does not have indexbuffer, go deeper
+	{
+		count = 0;
+		for (int i = 0; i < 4; i++)
+		{
+			if (node->nodes[i] != NULL)
+			{
+				count++;
+				RenderNode(node->nodes[i], viewFrustum, pDevCon);
+			}
+		}
+		if (count != 0) //if there are children we know this parent does not have triangles to render
+			return;
+
+	}
+	pDevCon->IASetIndexBuffer(node->indexBuffer, DXGI_FORMAT_R32_UINT, 0);
+	pDevCon->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+	indexCount = node->triangleCount * 3;
+
+	m_drawCount += node->triangleCount;
+
+	//set the vertex and index buffer and draw the triangles from this cube
+	pDevCon->DrawIndexed(indexCount, 0, 0);
+	
+	return;
+}
+
+void QuadTree::calculateNormalTangentBinormal(int v1, int v2, int v3, vector<VertexTypeHeightMap>& m_vertices)
+{
+	XMFLOAT3 vtx1, vtx2, vtx3;
+	XMFLOAT2 uv1, uv2, uv3;
+	XMFLOAT3 normal;
+
+	vtx1 = m_vertices[v1].vertex;
+	vtx2 = m_vertices[v2].vertex;
+	vtx3 = m_vertices[v3].vertex;
+
+	uv1 = m_vertices[v1].tex;
+	uv2 = m_vertices[v2].tex;
+	uv3 = m_vertices[v3].tex;
+
+	XMVECTOR edge1 = XMLoadFloat3(&vtx2) - XMLoadFloat3(&vtx1);
+	XMVECTOR edge2 = XMLoadFloat3(&vtx3) - XMLoadFloat3(&vtx1);
+
+	XMVECTOR n = XMVector3Normalize(XMVector3Cross(edge1, edge2));
+
+	XMStoreFloat3(&normal, n);
+
+	m_vertices[v1].normal = normal;
+	m_vertices[v2].normal = normal;
+	m_vertices[v3].normal = normal;
+
+	//load the data into XMVECTOR's so we can use DirectXMath functions/operators for calculations
+	XMVECTOR vertex0, vertex1, vertex2, tex0, tex1, tex2, normal0;
+	vertex0 = XMLoadFloat3(&vtx1);
+	vertex1 = XMLoadFloat3(&vtx2);
+	vertex2 = XMLoadFloat3(&vtx3);
+	tex0 = XMLoadFloat2(&uv1);
+	tex1 = XMLoadFloat2(&uv2);
+	tex2 = XMLoadFloat2(&uv3);
+	normal0 = XMLoadFloat3(&normal);
+
+	//do the math
+	XMVECTOR e1 = vertex1 - vertex0;
+	XMVECTOR e2 = vertex2 - vertex0;
+	XMVECTOR deltaUV1 = tex1 - tex0;
+	XMVECTOR deltaUV2 = tex2 - tex0;
+
+	XMVECTOR tangent;
+	XMVECTOR binormal;
+
+	float r = (deltaUV1.m128_f32[0] * deltaUV2.m128_f32[1] - deltaUV1.m128_f32[1] * deltaUV2.m128_f32[0]);
+	if (fabsf(r) < 1e-6f)
+	{
+		// Equal to zero (almost) means the surface lies flat on its back
+		tangent = XMVectorSet(1.0f, 0.0f, 0.0f, 0.0f);
+		binormal = XMVectorSet(0.0f, 0.0f, 1.0f, 0.0f);
+	}
+	else
+	{
+		r = 1.0f / r;
+		tangent = (e1 * deltaUV2.m128_f32[1] - e2 * deltaUV1.m128_f32[1]) * r;
+		binormal = (e2 * deltaUV1.m128_f32[0] - e1 * deltaUV2.m128_f32[0]) * r;
+
+		tangent = XMVector3Normalize(tangent);
+		binormal = XMVector3Normalize(binormal);
+	}
+
+	// As the bitangent equals to the cross product between the normal and the tangent running along the surface, calculate it
+	XMVECTOR bitangent = XMVector3Cross(normal0, tangent);
+
+	// Since we don't know if we must negate it, compare it with our computed one above
+	float crossinv = (XMVector3Dot(bitangent, binormal).m128_f32[0] < 0.0f) ? -1.0f : 1.0f;
+	bitangent *= crossinv;
+
+	XMStoreFloat3(&m_vertices[v1].tangent, tangent);
+	XMStoreFloat3(&m_vertices[v2].tangent, tangent);
+	XMStoreFloat3(&m_vertices[v3].tangent, tangent);
+
+	XMStoreFloat3(&m_vertices[v1].binormal, bitangent);
+	XMStoreFloat3(&m_vertices[v2].binormal, bitangent);
+	XMStoreFloat3(&m_vertices[v3].binormal, bitangent);
+}

--- a/QuadTree.h
+++ b/QuadTree.h
@@ -1,0 +1,64 @@
+#pragma once
+#ifndef QUADTREE_H
+#define QUADTREE_H
+
+#include <d3d11.h>
+#include <DirectXMath.h>
+#include <vector>
+#include "ViewFrustum.h"
+
+using namespace DirectX;
+using namespace std;
+
+struct VertexTypeHeightMap
+{
+	XMFLOAT3 vertex;
+	XMFLOAT2 tex;
+	XMFLOAT3 normal;
+	XMFLOAT3 tangent;
+	XMFLOAT3 binormal;
+};
+
+#define MAX_TRIANGLES 1000
+
+class QuadTree
+{
+public:
+
+	QuadTree();
+	~QuadTree();
+
+	bool initialize(vector<unsigned int> indices, int mapSize, float delta, ID3D11Device * pDev);
+	void Release();
+	void Render(ViewFrustum &viewFrustum, ID3D11DeviceContext * pDevCon);
+	int getTriangleCount() const { return m_drawCount; }
+
+
+private:
+	struct NodeTypeQuadTree
+	{
+		int xIndex;
+		int zIndex;
+		int size;
+		float radius;
+		int triangleCount;
+		XMFLOAT3 cubeCenterVertex;
+		ID3D11Buffer* indexBuffer;
+		NodeTypeQuadTree* nodes[4];
+	};
+	//methods
+	void createTreeNode(NodeTypeQuadTree *node, int XstartIndex, int zStartIndex, int size, ID3D11Device* pDev);
+	void ReleaseNode(NodeTypeQuadTree *node);
+	void RenderNode(NodeTypeQuadTree *node, ViewFrustum &viewFrustum,ID3D11DeviceContext *pDevCon);
+	void calculateNormalTangentBinormal(int v1, int v2, int v3, vector<VertexTypeHeightMap> &m_vertices);
+	//members
+	NodeTypeQuadTree * m_parent;
+	int m_mapSize;
+	int m_triangleCount;
+	int m_drawCount;
+	float deltaSpace; //the space that seperates the vertices, need this construct the center vertex of each cube
+	vector<unsigned int> m_indices;
+
+};
+#endif // !QUADTREE_H
+

--- a/SceneHeightMap.cpp
+++ b/SceneHeightMap.cpp
@@ -39,7 +39,7 @@ void SceneHeightMap::renderScene(Application * pApp)
 	pApp->pDevCon->ClearDepthStencilView(pApp->pDSV, D3D11_CLEAR_DEPTH, 1.0f, 0);
 
 	//render map
-	m_heightMap->Render(pApp->pDevCon, XMMatrixIdentity(), pApp->view, pApp->projection);
+	m_heightMap->Render(pApp, XMMatrixIdentity(), pApp->view, pApp->projection);
 
 	//text output
 	pApp->textToScreen(L"Scene 4", XMFLOAT2(50.f, 50.f), XMFLOAT2(0.5f, 0.5f));

--- a/SceneHeightMap.h
+++ b/SceneHeightMap.h
@@ -6,6 +6,7 @@
 #include "Application.h"
 
 using namespace DirectX;
+class HeightMap;
 
 class SceneHeightMap
 {

--- a/ViewFrustum.cpp
+++ b/ViewFrustum.cpp
@@ -1,0 +1,147 @@
+#include "ViewFrustum.h"
+
+
+
+ViewFrustum::ViewFrustum()
+{
+	for (int i = 0; i < 6; i++)
+		planes[i] = g_XMZero;
+}
+
+
+ViewFrustum::~ViewFrustum()
+{
+}
+
+void ViewFrustum::buildFrustum(float depth, XMMATRIX view, XMMATRIX projection)
+{
+	float zMin, r;
+	XMMATRIX matrix;
+	XMFLOAT4X4 _view, _proj, _m;
+	XMStoreFloat4x4(&_view, view);
+	XMStoreFloat4x4(&_proj, projection);
+
+	//calculate the min Z distance in the frustum
+	zMin = -_proj._43 / _proj._33;
+	r = depth / (depth - zMin);
+	_proj._33 = r;
+	_proj._43 = -r * zMin;
+
+	//create the frustum matrix
+	projection = XMLoadFloat4x4(&_proj);
+	matrix = XMMatrixMultiply(view, projection);
+	XMStoreFloat4x4(&_m, matrix);
+
+	//calculate and store the planes
+	XMFLOAT4 plane;
+
+	//near plane
+	plane.x = _m._14 + _m._13;
+	plane.y = _m._24 + _m._23;
+	plane.z = _m._34 + _m._33;
+	plane.w = _m._44 + _m._43;
+	planes[0] = XMLoadFloat4(&plane);
+
+	//far plane
+	plane.x = _m._14 - _m._13;
+	plane.y = _m._24 - _m._23;
+	plane.z = _m._34 - _m._33;
+	plane.w = _m._44 - _m._43;
+	planes[1] = XMLoadFloat4(&plane);
+
+	//left plane
+	plane.x = _m._14 + _m._11;
+	plane.y = _m._24 + _m._21;
+	plane.z = _m._34 + _m._31;
+	plane.w = _m._44 + _m._41;
+	planes[2] = XMLoadFloat4(&plane);
+
+	//right plane
+	plane.x = _m._14 - _m._11;
+	plane.y = _m._24 - _m._21;
+	plane.z = _m._34 - _m._31;
+	plane.w = _m._44 - _m._41;
+	planes[3] = XMLoadFloat4(&plane);
+
+	//top plane
+	plane.x = _m._14 - _m._12;
+	plane.y = _m._24 - _m._22;
+	plane.z = _m._34 - _m._32;
+	plane.w = _m._44 - _m._42;
+	planes[4] = XMLoadFloat4(&plane);
+
+	//bottom plane
+	plane.x = _m._14 + _m._12;
+	plane.y = _m._24 + _m._22;
+	plane.z = _m._34 + _m._32;
+	plane.w = _m._44 + _m._42;
+	planes[5] = XMLoadFloat4(&plane);
+
+	//normalize the planes
+	for (int i = 0; i < 6; i++)
+	{
+		planes[i] = XMPlaneNormalize(planes[i]);
+	}
+	//done
+}
+
+bool ViewFrustum::checkPoint(XMFLOAT3 point)
+{
+	//check if the point is inside all the six planes
+	for (int i = 0; i < 6; i++)
+	{
+		if (XMPlaneDotCoord(planes[i], XMLoadFloat3(&point)).m128_f32[0] < 0.0f)
+		{
+			return false; //the point is outside the view frustum
+		}
+	}
+	return true;
+}
+
+bool ViewFrustum::checkCube(XMFLOAT3 center, float radius)
+{
+	for (int i = 0; i < 6; i++)
+	{
+		if (XMPlaneDotCoord(planes[i], XMVectorSet((center.x - radius), (center.y - radius), (center.z - radius), 0.0f)).m128_f32[0] >= 0.0f)
+		{
+			continue; //this point is inside
+		}
+
+		if (XMPlaneDotCoord(planes[i], XMVectorSet((center.x + radius), (center.y - radius), (center.z - radius), 0.0f)).m128_f32[0] >= 0.0f)
+		{
+			continue; //this point is inside
+		}
+
+		if (XMPlaneDotCoord(planes[i], XMVectorSet((center.x - radius), (center.y + radius), (center.z - radius), 0.0f)).m128_f32[0] >= 0.0f)
+		{
+			continue; //this point is inside
+		}
+
+		if (XMPlaneDotCoord(planes[i], XMVectorSet((center.x + radius), (center.y + radius), (center.z - radius), 0.0f)).m128_f32[0] >= 0.0f)
+		{
+			continue; //this point is inside
+		}
+
+		if (XMPlaneDotCoord(planes[i], XMVectorSet((center.x - radius), (center.y - radius), (center.z + radius), 0.0f)).m128_f32[0] >= 0.0f)
+		{
+			continue; //this point is inside
+		}
+
+		if (XMPlaneDotCoord(planes[i], XMVectorSet((center.x + radius), (center.y - radius), (center.z + radius), 0.0f)).m128_f32[0] >= 0.0f)
+		{
+			continue; //this point is inside
+		}
+
+		if (XMPlaneDotCoord(planes[i], XMVectorSet((center.x - radius), (center.y + radius), (center.z + radius), 0.0f)).m128_f32[0] >= 0.0f)
+		{
+			continue; //this point is inside
+		}
+
+		if (XMPlaneDotCoord(planes[i], XMVectorSet((center.x + radius), (center.y + radius), (center.z + radius), 0.0f)).m128_f32[0] >= 0.0f)
+		{
+			continue; //this point is inside
+		}
+		return true; //if we get to this point we know its outside the frustum and can be culled
+	}
+	return false;
+}

--- a/ViewFrustum.h
+++ b/ViewFrustum.h
@@ -1,0 +1,24 @@
+#pragma once
+#ifndef VIEWFRUSTUM_H
+#define VIEWFRUSTUM_H
+
+#include <DirectXMath.h>
+
+using namespace DirectX;
+
+class ViewFrustum
+{
+public:
+	ViewFrustum();
+	~ViewFrustum();
+
+	void buildFrustum(float depth, XMMATRIX view, XMMATRIX projection);
+
+	bool checkPoint(XMFLOAT3 point);
+	bool checkCube(XMFLOAT3 center, float radius);
+
+private:
+	XMVECTOR planes[6];
+};
+
+#endif // !VIEWFRUSTUM_H


### PR DESCRIPTION
View frustum culling on Quad tree added. I have also added a top down view for the first render pass so we can in real time see what quads are being rendered. In the second render call we just render the scene as usual. Loading big maps take a lot time, especially when you run in Debug mode, so I advice you to run it in release. There is also a weird bug with the camera when the map is too big and you travel too far it suddenly gets inverted. I have no idea why. But on a map of the size of 2^7 + 1, ther is no problems and as usual play around with the parameters for map creation. Important note: Do not make mountains too big, then the view frustum culling will cull things that should not be culled because of the height value (it will cull depending of the cube radius). Meaning that if you have a small map, but high peaks and you travel upward, if the camera position is above the radius (radius is depending the map/cube size) the entire quad will be culled since its now "outside" the frustum.